### PR TITLE
fix(purchase): detect legacy payable accounts by description

### DIFF
--- a/src/main/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolver.java
+++ b/src/main/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolver.java
@@ -78,10 +78,16 @@ public class PayableAccountDefaultResolver {
         String classification = account.classification() == null
                 ? ""
                 : account.classification().toLowerCase(Locale.ROOT);
+        String description = account.description() == null
+                ? ""
+                : account.description().toLowerCase(Locale.ROOT);
         if (code.startsWith("22")) {
             return true;
         }
-        return classification.contains("pasivo corriente");
+        return classification.contains("pasivo corriente")
+                || description.contains("cuentas por pagar")
+                || description.contains("cuenta por pagar")
+                || description.contains("proveedores");
     }
 
     private boolean isActive(CatalogueAccount account) {
@@ -105,6 +111,7 @@ public class PayableAccountDefaultResolver {
                 accounts.add(new CatalogueAccount(
                         node.path("id").asLong(),
                         textOrNull(node, "code"),
+                        textOrNull(node, "description"),
                         textOrNull(node, "classification"),
                         node.has("status") && !node.get("status").isNull() ? node.get("status").asBoolean() : null));
             }
@@ -123,5 +130,5 @@ public class PayableAccountDefaultResolver {
         return value.asText();
     }
 
-    record CatalogueAccount(Long id, String code, String classification, Boolean status) {}
+    record CatalogueAccount(Long id, String code, String description, String classification, Boolean status) {}
 }

--- a/src/test/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolverUnitTest.java
+++ b/src/test/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolverUnitTest.java
@@ -54,6 +54,18 @@ class PayableAccountDefaultResolverUnitTest {
     }
 
     @Test
+    void resolvesPayableAccountByDescriptionForLegacyCatalogue() {
+        stubCatalogue("""
+                [
+                  {"id":10,"code":"1105","description":"Caja","classification":"Activo Corriente","status":true},
+                  {"id":21,"code":"2105","description":"Cuentas por pagar","classification":"Pasivo No Corriente","status":true}
+                ]
+                """);
+
+        assertThat(resolver.resolveForPurchase(null, "enterprise-a")).isEqualTo(21L);
+    }
+
+    @Test
     void rejectsInactiveExplicitPayableAccount() {
         stubCatalogue("""
                 [{"id":55,"code":"22050101","classification":"Pasivo Corriente","status":false}]


### PR DESCRIPTION
## Summary
- recognize active catalogue accounts named Cuentas por pagar or Proveedores
- preserve existing 22-prefix and Pasivo Corriente rules
- cover legacy code 2105 with a resolver unit test

## Test plan
- [x] `.\mvnw.cmd -q -Dtest=PayableAccountDefaultResolverUnitTest test`

Made with [Cursor](https://cursor.com)