### PR TITLE
fix(purchase): clarify catalogue errors when saving purchase invoice

### DIFF
--- a/src/main/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolver.java
+++ b/src/main/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolver.java
@@ -22,6 +22,13 @@ import org.springframework.web.client.RestClient;
 @Slf4j
 public class PayableAccountDefaultResolver {
 
+    static final String NO_VALID_CATALOGUE_MESSAGE =
+            "La empresa aún no tiene un catálogo de cuentas válido. Configure el catálogo de cuentas "
+                    + "en Maestros Generales antes de registrar facturas de compra.";
+    static final String NO_ACTIVE_PAYABLE_MESSAGE =
+            "El catálogo de la empresa no tiene cuentas por pagar activas. Cree o active una cuenta CxP "
+                    + "(por ejemplo código 22xxxx) en el catálogo de cuentas.";
+
     private final RestClient client;
     private final IJwtUtils jwtUtils;
     private final ObjectMapper objectMapper;
@@ -40,6 +47,9 @@ public class PayableAccountDefaultResolver {
      */
     public Long resolveForPurchase(Long requestedAccountId, String enterpriseId) {
         List<CatalogueAccount> accounts = loadAccounts(enterpriseId);
+        if (accounts.isEmpty()) {
+            throw new IllegalArgumentException(NO_VALID_CATALOGUE_MESSAGE);
+        }
         if (requestedAccountId != null) {
             CatalogueAccount explicit = accounts.stream()
                     .filter(account -> requestedAccountId.equals(account.id()))
@@ -58,8 +68,7 @@ public class PayableAccountDefaultResolver {
         }
         return selectDefaultPayable(accounts)
                 .map(CatalogueAccount::id)
-                .orElseThrow(() -> new IllegalStateException(
-                        "No hay cuentas por pagar activas en el catálogo para la empresa " + enterpriseId));
+                .orElseThrow(() -> new IllegalArgumentException(NO_ACTIVE_PAYABLE_MESSAGE));
     }
 
     private Optional<CatalogueAccount> selectDefaultPayable(List<CatalogueAccount> accounts) {

--- a/src/main/java/com/facturemanagement/infraestructure/adapters/output/customizedexception/CustomizedExceptionAdapter.java
+++ b/src/main/java/com/facturemanagement/infraestructure/adapters/output/customizedexception/CustomizedExceptionAdapter.java
@@ -51,6 +51,14 @@ public class CustomizedExceptionAdapter extends ResponseEntityExceptionHandler {
      * @return un ResponseEntity que contiene un ExceptionResponse
      *         con los detalles de la excepción y un estado NOT_FOUND
      */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public final ResponseEntity<Object> handleIllegalArgumentException(IllegalArgumentException ex, WebRequest request) {
+        ExceptionResponse exceptionResponse = new ExceptionResponse(LocalDateTime.now(), ex.getMessage(),
+                Arrays.asList(request.getDescription(false)));
+
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+
     @ExceptionHandler(FactureNotFound.class)
     public final ResponseEntity<Object> handleUserNotFoundException(FactureNotFound ex, WebRequest request) {
         ExceptionResponse exceptionResponse = new ExceptionResponse(LocalDateTime.now(), ex.getMessage(),

--- a/src/test/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolverUnitTest.java
+++ b/src/test/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolverUnitTest.java
@@ -77,14 +77,23 @@ class PayableAccountDefaultResolverUnitTest {
     }
 
     @Test
+    void rejectsWhenCatalogueIsEmpty() {
+        stubCatalogue("[]");
+
+        assertThatThrownBy(() -> resolver.resolveForPurchase(null, "enterprise-a"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("catálogo de cuentas válido");
+    }
+
+    @Test
     void rejectsWhenNoActivePayableExists() {
         stubCatalogue("""
                 [{"id":1,"code":"1105","classification":"Activo Corriente","status":true}]
                 """);
 
         assertThatThrownBy(() -> resolver.resolveForPurchase(null, "enterprise-a"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("No hay cuentas por pagar activas");
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no tiene cuentas por pagar activas");
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Empty catalogue: user-friendly message to configure catálogo in Maestros Generales
- Catalogue without active CxP: message to create/activate payable account
- IllegalArgumentException now returns HTTP 400 instead of 500

## Test plan
- [ ] PayableAccountDefaultResolverUnitTest
- [ ] Save purchase invoice without catalogue shows clear message
