### PR TITLE
fix(purchase): restrict default CxP to supplier payable accounts

### DIFF
--- a/src/main/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolver.java
+++ b/src/main/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolver.java
@@ -16,7 +16,7 @@ import org.springframework.web.client.RestClient;
 
 /**
  * Resuelve la cuenta CxP para facturas de compra consultando el catálogo real.
- * Alineado con la regla de Tesorería: pasivo corriente o código PUC 22xxxx.
+ * Solo acepta cuentas con semántica de obligaciones con proveedores (CxP / proveedores).
  */
 @Component
 @Slf4j
@@ -26,8 +26,7 @@ public class PayableAccountDefaultResolver {
             "La empresa aún no tiene un catálogo de cuentas válido. Configure el catálogo de cuentas "
                     + "en Maestros Generales antes de registrar facturas de compra.";
     static final String NO_ACTIVE_PAYABLE_MESSAGE =
-            "El catálogo de la empresa no tiene cuentas por pagar activas. Cree o active una cuenta CxP "
-                    + "(por ejemplo código 22xxxx) en el catálogo de cuentas.";
+            "La empresa no tiene configurada una Cuenta por Pagar activa en el catálogo de cuentas.";
 
     private final RestClient client;
     private final IJwtUtils jwtUtils;
@@ -73,30 +72,77 @@ public class PayableAccountDefaultResolver {
 
     private Optional<CatalogueAccount> selectDefaultPayable(List<CatalogueAccount> accounts) {
         return accounts.stream()
-                .filter(account -> isActive(account) && isPayableAccount(account))
+                .filter(this::isPayableAccount)
                 .sorted(Comparator
-                        .comparingInt((CatalogueAccount account) -> account.code() == null ? 0 : account.code().length())
-                        .reversed()
-                        .thenComparing(CatalogueAccount::code, Comparator.nullsLast(String::compareTo)))
+                        .comparingInt(this::payableSelectionPriority)
+                        .thenComparing(account -> account.code() == null ? "" : account.code()))
                 .findFirst();
     }
 
-    /** Misma regla que expense-receipt-creation en ContAppAng19. */
+    /**
+     * Cuenta elegible solo si representa CxP/proveedores según nombre/descripción del catálogo.
+     * No basta con ser pasivo ni con comenzar por 22.
+     */
     boolean isPayableAccount(CatalogueAccount account) {
-        String code = account.code() == null ? "" : account.code();
-        String classification = account.classification() == null
-                ? ""
-                : account.classification().toLowerCase(Locale.ROOT);
-        String description = account.description() == null
-                ? ""
-                : account.description().toLowerCase(Locale.ROOT);
-        if (code.startsWith("22")) {
+        if (!isActive(account)) {
+            return false;
+        }
+        String code = normalized(account.code());
+        String description = normalized(account.description());
+        if (isExcludedFromSupplierPayables(code, description)) {
+            return false;
+        }
+        return matchesSupplierPayableSemantics(description);
+    }
+
+    private boolean isExcludedFromSupplierPayables(String code, String description) {
+        if (code.startsWith("11")) {
             return true;
         }
-        return classification.contains("pasivo corriente")
-                || description.contains("cuentas por pagar")
+        if (description.contains("caja")
+                || description.contains("banco")
+                || description.contains("efectivo")
+                || description.contains("reserva")) {
+            return true;
+        }
+        return description.contains("beneficios a empleados")
+                || description.contains("beneficio a empleado")
+                || description.contains("obligaciones laborales")
+                || description.contains("obligacion laboral")
+                || description.contains("obligaciones financieras")
+                || description.contains("obligacion financiera")
+                || description.contains("impuestos por pagar")
+                || description.contains("impuesto por pagar")
+                || description.contains("salarios por pagar")
+                || description.contains("salario por pagar")
+                || description.contains("retenciones por pagar")
+                || description.contains("retencion por pagar")
+                || description.contains("nomina por pagar")
+                || description.contains("nómina por pagar");
+    }
+
+    private boolean matchesSupplierPayableSemantics(String description) {
+        return description.contains("cuentas por pagar")
                 || description.contains("cuenta por pagar")
-                || description.contains("proveedores");
+                || description.contains("proveedores")
+                || description.contains("proveedor nacional")
+                || description.contains("proveedor extranjero")
+                || description.contains("proveedor ");
+    }
+
+    private int payableSelectionPriority(CatalogueAccount account) {
+        String description = normalized(account.description());
+        if (description.contains("cuenta por pagar") || description.contains("cuentas por pagar")) {
+            return 0;
+        }
+        if (description.contains("proveedor")) {
+            return 1;
+        }
+        return 2;
+    }
+
+    private static String normalized(String value) {
+        return value == null ? "" : value.toLowerCase(Locale.ROOT).trim();
     }
 
     private boolean isActive(CatalogueAccount account) {

--- a/src/test/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolverUnitTest.java
+++ b/src/test/java/com/facturemanagement/application/service/skeleton/service/PayableAccountDefaultResolverUnitTest.java
@@ -41,24 +41,12 @@ class PayableAccountDefaultResolverUnitTest {
     }
 
     @Test
-    void resolvesDefaultActivePayableAccountFromCatalogue() {
-        stubCatalogue("""
-                [
-                  {"id":10,"code":"1105","classification":"Activo Corriente","status":true},
-                  {"id":99,"code":"22050101","classification":"Pasivo Corriente","status":true},
-                  {"id":98,"code":"2205","classification":"Pasivo No Corriente","status":true}
-                ]
-                """);
-
-        assertThat(resolver.resolveForPurchase(null, "enterprise-a")).isEqualTo(99L);
-    }
-
-    @Test
-    void resolvesPayableAccountByDescriptionForLegacyCatalogue() {
+    void resolvesDefaultSupplierPayableAccountFromCatalogue() {
         stubCatalogue("""
                 [
                   {"id":10,"code":"1105","description":"Caja","classification":"Activo Corriente","status":true},
-                  {"id":21,"code":"2105","description":"Cuentas por pagar","classification":"Pasivo No Corriente","status":true}
+                  {"id":24,"code":"2206","description":"Beneficios a empleados a largo plazo","classification":"Pasivo No Corriente","status":true},
+                  {"id":21,"code":"2105","description":"Cuentas por pagar","classification":"Pasivo Corriente","status":true}
                 ]
                 """);
 
@@ -66,9 +54,60 @@ class PayableAccountDefaultResolverUnitTest {
     }
 
     @Test
+    void acceptsAccountsPayableDescription() {
+        stubCatalogue("""
+                [{"id":21,"code":"2105","description":"Cuentas por pagar","classification":"Pasivo Corriente","status":true}]
+                """);
+
+        assertThat(resolver.resolveForPurchase(null, "enterprise-a")).isEqualTo(21L);
+    }
+
+    @Test
+    void acceptsSuppliersDescription() {
+        stubCatalogue("""
+                [{"id":30,"code":"220501","description":"Proveedores nacionales","classification":"Pasivo Corriente","status":true}]
+                """);
+
+        assertThat(resolver.resolveForPurchase(null, "enterprise-a")).isEqualTo(30L);
+    }
+
+    @Test
+    void rejectsCashAccount() {
+        stubCatalogue("""
+                [{"id":10,"code":"1105","description":"Caja","classification":"Activo Corriente","status":true}]
+                """);
+
+        assertThatThrownBy(() -> resolver.resolveForPurchase(null, "enterprise-a"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cuenta por Pagar activa");
+    }
+
+    @Test
+    void rejectsEmployeeBenefitsAccount() {
+        stubCatalogue("""
+                [{"id":24,"code":"2206","description":"Beneficios a empleados a largo plazo","classification":"Pasivo No Corriente","status":true}]
+                """);
+
+        assertThatThrownBy(() -> resolver.resolveForPurchase(null, "enterprise-a"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cuenta por Pagar activa");
+    }
+
+    @Test
+    void rejectsLaborObligationsAccount() {
+        stubCatalogue("""
+                [{"id":31,"code":"2510","description":"Obligaciones laborales","classification":"Pasivo Corriente","status":true}]
+                """);
+
+        assertThatThrownBy(() -> resolver.resolveForPurchase(null, "enterprise-a"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Cuenta por Pagar activa");
+    }
+
+    @Test
     void rejectsInactiveExplicitPayableAccount() {
         stubCatalogue("""
-                [{"id":55,"code":"22050101","classification":"Pasivo Corriente","status":false}]
+                [{"id":55,"code":"2105","description":"Cuentas por pagar","classification":"Pasivo Corriente","status":false}]
                 """);
 
         assertThatThrownBy(() -> resolver.resolveForPurchase(55L, "enterprise-a"))
@@ -86,23 +125,50 @@ class PayableAccountDefaultResolverUnitTest {
     }
 
     @Test
-    void rejectsWhenNoActivePayableExists() {
+    void rejectsWhenNoSupplierPayableExists() {
         stubCatalogue("""
-                [{"id":1,"code":"1105","classification":"Activo Corriente","status":true}]
+                [
+                  {"id":1,"code":"1105","description":"Caja","classification":"Activo Corriente","status":true},
+                  {"id":2,"code":"2206","description":"Beneficios a empleados a largo plazo","classification":"Pasivo No Corriente","status":true},
+                  {"id":3,"code":"2205","description":"Obligaciones financieras no corrientes","classification":"Pasivo No Corriente","status":true}
+                ]
                 """);
 
         assertThatThrownBy(() -> resolver.resolveForPurchase(null, "enterprise-a"))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("no tiene cuentas por pagar activas");
+                .hasMessageContaining("Cuenta por Pagar activa");
     }
 
     @Test
-    void acceptsExplicitActivePayableAccount() {
+    void acceptsExplicitActiveSupplierPayableAccount() {
         stubCatalogue("""
-                [{"id":77,"code":"22050101","classification":"Pasivo Corriente","status":true}]
+                [{"id":77,"code":"2105","description":"Cuentas por pagar","classification":"Pasivo Corriente","status":true}]
                 """);
 
         assertThat(resolver.resolveForPurchase(77L, "enterprise-a")).isEqualTo(77L);
+    }
+
+    @Test
+    void rejectsExplicitNonSupplierPayableAccount() {
+        stubCatalogue("""
+                [{"id":24,"code":"2206","description":"Beneficios a empleados a largo plazo","classification":"Pasivo No Corriente","status":true}]
+                """);
+
+        assertThatThrownBy(() -> resolver.resolveForPurchase(24L, "enterprise-a"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("no es una cuenta por pagar válida");
+    }
+
+    @Test
+    void prefersAccountsPayableOverSuppliersWhenBothExist() {
+        stubCatalogue("""
+                [
+                  {"id":30,"code":"220501","description":"Proveedores","classification":"Pasivo Corriente","status":true},
+                  {"id":21,"code":"2105","description":"Cuentas por pagar","classification":"Pasivo Corriente","status":true}
+                ]
+                """);
+
+        assertThat(resolver.resolveForPurchase(null, "enterprise-a")).isEqualTo(21L);
     }
 
     private void stubCatalogue(String jsonBody) {


### PR DESCRIPTION
## Summary
- Restrict automatic purchase invoice CxP resolution to supplier payable accounts (Cuentas por pagar / Proveedores).
- Reject cash, employee benefits, labor/financial liabilities and other non-supplier accounts.
- Block purchase creation when no valid supplier CxP exists in catalogue.

## Test plan
- [x] PayableAccountDefaultResolverUnitTest (12 cases)
- [x] Local E2E validated: CxP 2105 selected, 2206/Caja rejected
- [ ] CI

## Impact
Facture purchase invoices only; Treasury sync consumes resolved accountingAccount.