### PR TITLE
fix(facture): validate purchase invoice balances

### DIFF
--- a/src/main/java/com/facturemanagement/application/service/skeleton/service/SkeletonFactureService.java
+++ b/src/main/java/com/facturemanagement/application/service/skeleton/service/SkeletonFactureService.java
@@ -16,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -188,6 +189,7 @@ public class SkeletonFactureService {
     }
 
     private void preparePurchaseRequest(SkeletonFactureRequestDto request) {
+        validatePurchaseBalance(request);
         if (request.getFactCode() == null || request.getFactCode() <= 0) {
             request.setFactCode(System.currentTimeMillis() % 1_000_000_000L);
         }
@@ -196,5 +198,26 @@ public class SkeletonFactureService {
         }
         request.setAccountingAccount(
                 payableAccountDefaultResolver.resolveForPurchase(request.getAccountingAccount(), request.getEntId()));
+    }
+
+    private void validatePurchaseBalance(SkeletonFactureRequestDto request) {
+        BigDecimal totalValue = amount(request.getTotalValue(), "totalValue");
+        BigDecimal totalPay = amount(request.getTotalPay(), "totalPay");
+        BigDecimal pendingValue = amount(request.getPendingValue(), "pendingValue");
+
+        if (totalValue.signum() < 0 || totalPay.signum() < 0 || pendingValue.signum() < 0) {
+            throw new IllegalArgumentException("Los valores total, pagado y pendiente no pueden ser negativos");
+        }
+        if (pendingValue.compareTo(totalValue.subtract(totalPay)) != 0) {
+            throw new IllegalArgumentException("El valor pendiente debe ser igual al total menos el valor pagado");
+        }
+    }
+
+    private BigDecimal amount(String value, String field) {
+        try {
+            return new BigDecimal(value);
+        } catch (NumberFormatException | NullPointerException ex) {
+            throw new IllegalArgumentException("El campo " + field + " debe contener un valor numerico valido", ex);
+        }
     }
 }

--- a/src/test/java/com/facturemanagement/application/service/skeleton/service/PurchaseInvoiceOutboxServiceUnitTest.java
+++ b/src/test/java/com/facturemanagement/application/service/skeleton/service/PurchaseInvoiceOutboxServiceUnitTest.java
@@ -1,0 +1,98 @@
+package com.facturemanagement.application.service.skeleton.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.facturemanagement.application.service.skeleton.model.PurchaseInvoiceOutboxEvent;
+import com.facturemanagement.application.service.skeleton.model.PurchaseInvoiceStatus;
+import com.facturemanagement.application.service.skeleton.model.SkeletonFacture;
+import com.facturemanagement.application.service.skeleton.model.SkeletonFactureType;
+import com.facturemanagement.application.service.skeleton.repository.PurchaseInvoiceOutboxRepository;
+import com.facturemanagement.infraestructure.adapters.output.messageBroker.PurchaseInvoiceEventPublisher;
+import com.facturemanagement.infraestructure.adapters.output.persistence.multitenancy.util.TenantContext;
+import java.time.LocalDate;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+class PurchaseInvoiceOutboxServiceUnitTest {
+    private PurchaseInvoiceOutboxRepository repository;
+    private PayableAccountCodeResolver accountCodes;
+    private PurchaseInvoiceEventPublisher publisher;
+    private PurchaseInvoiceOutboxService service;
+
+    @BeforeEach
+    void setUp() {
+        repository = mock(PurchaseInvoiceOutboxRepository.class);
+        accountCodes = mock(PayableAccountCodeResolver.class);
+        publisher = mock(PurchaseInvoiceEventPublisher.class);
+        service = new PurchaseInvoiceOutboxService(
+                repository, new ObjectMapper().findAndRegisterModules(), accountCodes, publisher);
+        TenantContext.setTenantId("tenant-a");
+    }
+
+    @AfterEach
+    void clearTenant() {
+        TenantContext.clear();
+    }
+
+    @Test
+    void publishesFreshPurchaseWithStableIdentifiersBalancesAndActiveFlag() throws Exception {
+        when(accountCodes.resolveOrFail(55L, "enterprise-a")).thenReturn("220501");
+
+        service.enqueue(invoice(), "PURCHASE_INVOICE_CREATED");
+
+        ArgumentCaptor<PurchaseInvoiceOutboxEvent> captured =
+                ArgumentCaptor.forClass(PurchaseInvoiceOutboxEvent.class);
+        verify(publisher).publish(captured.capture());
+        PurchaseInvoiceOutboxEvent event = captured.getValue();
+        var envelope = new ObjectMapper().findAndRegisterModules().readTree(event.getPayload());
+        var payload = envelope.get("payload");
+        assertThat(envelope.get("tenantId").asText()).isEqualTo("tenant-a");
+        assertThat(envelope.get("enterpriseId").asText()).isEqualTo("enterprise-a");
+        assertThat(payload.get("tenantId").asText()).isEqualTo("tenant-a");
+        assertThat(payload.get("enterpriseId").asText()).isEqualTo("enterprise-a");
+        assertThat(payload.get("invoiceId").asLong()).isEqualTo(10L);
+        assertThat(payload.get("supplierId").asLong()).isEqualTo(77L);
+        assertThat(payload.get("originalAmount").decimalValue()).isEqualByComparingTo("100000");
+        assertThat(payload.get("paidAmount").decimalValue()).isEqualByComparingTo("40000");
+        assertThat(payload.get("pendingAmount").decimalValue()).isEqualByComparingTo("60000");
+        assertThat(payload.get("active").asBoolean()).isTrue();
+        assertThat(payload.get("payableAccountId").asLong()).isEqualTo(55L);
+        assertThat(payload.get("payableAccountCode").asText()).isEqualTo("220501");
+        assertThat(event.getStatus()).isEqualTo(PurchaseInvoiceOutboxEvent.Status.PUBLISHED);
+    }
+
+    @Test
+    void propagatesTemporaryPublishFailureSoOwningTransactionCanRollBack() throws Exception {
+        when(accountCodes.resolveOrFail(55L, "enterprise-a")).thenReturn("220501");
+        doThrow(new IllegalStateException("rabbit unavailable"))
+                .when(publisher).publish(org.mockito.ArgumentMatchers.any());
+
+        assertThatThrownBy(() -> service.enqueue(invoice(), "PURCHASE_INVOICE_CREATED"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("publicar");
+    }
+
+    private SkeletonFacture invoice() {
+        return SkeletonFacture.builder()
+                .id(10L)
+                .factCode(90010L)
+                .entId("enterprise-a")
+                .thId(77L)
+                .totalValue("100000")
+                .totalPay("40000")
+                .pendingValue("60000")
+                .expirationDate(LocalDate.of(2026, 9, 16))
+                .accountingAccount(55L)
+                .factureType(SkeletonFactureType.PURCHASE)
+                .purchaseStatus(PurchaseInvoiceStatus.ACTIVE)
+                .build();
+    }
+}

--- a/src/test/java/com/facturemanagement/application/service/skeleton/service/SkeletonFactureServicePurchaseUnitTest.java
+++ b/src/test/java/com/facturemanagement/application/service/skeleton/service/SkeletonFactureServicePurchaseUnitTest.java
@@ -60,6 +60,60 @@ class SkeletonFactureServicePurchaseUnitTest {
     }
 
     @Test
+    void acceptsFullyPendingPurchase() {
+        SkeletonFactureRequestDto request = request(1101L, "100000", "0", "100000");
+
+        prepareSuccessfulCreate(request, invoice(11L, PurchaseInvoiceStatus.ACTIVE));
+
+        service.createPurchase(request);
+
+        verify(outbox).enqueue(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.eq("PURCHASE_INVOICE_CREATED"));
+    }
+
+    @Test
+    void acceptsPurchaseWithInitialPartialPayment() {
+        SkeletonFactureRequestDto request = request(1102L, "100000.00", "40000.0", "60000");
+
+        prepareSuccessfulCreate(request, invoice(12L, PurchaseInvoiceStatus.ACTIVE));
+
+        service.createPurchase(request);
+
+        verify(factureRepository).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void acceptsFullyPaidPurchase() {
+        SkeletonFactureRequestDto request = request(1103L, "100000", "100000", "0.00");
+
+        prepareSuccessfulCreate(request, invoice(13L, PurchaseInvoiceStatus.ACTIVE));
+
+        service.createPurchase(request);
+
+        verify(factureRepository).save(org.mockito.ArgumentMatchers.any());
+    }
+
+    @Test
+    void rejectsInconsistentPurchaseBalanceBeforePersistence() {
+        SkeletonFactureRequestDto request = request(1104L, "100000", "40000", "70000");
+
+        assertThatThrownBy(() -> service.createPurchase(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("pendiente");
+
+        verify(factureRepository, never()).save(org.mockito.ArgumentMatchers.any());
+        verify(outbox, never()).enqueue(org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.anyString());
+    }
+
+    @Test
+    void rejectsNegativePurchaseAmounts() {
+        SkeletonFactureRequestDto request = request(1105L, "100000", "-1", "100001");
+
+        assertThatThrownBy(() -> service.createPurchase(request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("negativos");
+    }
+
+    @Test
     void updatePurchaseEnqueuesUpdatedEvent() {
         SkeletonFacture current = invoice(1L, PurchaseInvoiceStatus.ACTIVE);
         SkeletonFacture replacement = invoice(null, PurchaseInvoiceStatus.ACTIVE);
@@ -117,12 +171,27 @@ class SkeletonFactureServicePurchaseUnitTest {
     }
 
     private SkeletonFactureRequestDto request(long code) {
+        return request(code, "100", "0", "100");
+    }
+
+    private SkeletonFactureRequestDto request(long code, String total, String paid, String pending) {
         return SkeletonFactureRequestDto.builder()
                 .factCode(code)
                 .entId("enterprise-a")
                 .factureType(SkeletonFactureType.PURCHASE)
                 .products(Set.of())
+                .totalValue(total)
+                .totalPay(paid)
+                .pendingValue(pending)
                 .build();
+    }
+
+    private void prepareSuccessfulCreate(SkeletonFactureRequestDto request, SkeletonFacture invoice) {
+        SkeletonFactureDetailDto response = SkeletonFactureDetailDto.builder().id(invoice.getId()).build();
+        when(payableAccountDefaultResolver.resolveForPurchase(null, "enterprise-a")).thenReturn(2205L);
+        when(mapper.toEntity(request)).thenReturn(invoice);
+        when(factureRepository.save(invoice)).thenReturn(invoice);
+        when(mapper.toDetailDto(invoice)).thenReturn(response);
     }
 
     private SkeletonFacture invoice(Long id, PurchaseInvoiceStatus status) {


### PR DESCRIPTION
Facture valida los saldos de facturas de compra antes de persistir y publicar.

- Valida totalValue, totalPay y pendingValue.
- Rechaza valores negativos.
- Exige pendingValue = totalValue - totalPay.
- Mantiene rollback si falla publicaci?n Rabbit.
- Agrega pruebas de PURCHASE.

Validaciones:
- `mvnw clean verify`: 27/27 PASS.
- `git diff --check`: PASS.
